### PR TITLE
[useInterval] Cleanup previous interval

### DIFF
--- a/src/useInterval.js
+++ b/src/useInterval.js
@@ -31,6 +31,9 @@ const useInterval = (fn, milliseconds, options = defaultOptions) => {
 
   // when the milliseconds change, reset the timeout
   useEffect(() => {
+    // cleanup previous interval
+    clear();
+    
     if (typeof milliseconds === 'number') {
       timeout.current = setInterval(() => {
         callback.current();


### PR DESCRIPTION
Clear previous interval whem milliseconds changed. This will also allow to stop inteval when null was passed for milliseconds 
<!--- Provide a general summary of your changes in the Title above -->

## Related Issue
https://github.com/beautifulinteractions/beautiful-react-hooks/issues/85
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This pull request solves problem with producing new interval when milliseconds chnaged
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


